### PR TITLE
Fix deadlock between JavaFX and AWT threads during table initialization

### DIFF
--- a/jskat-javafx-gui/src/main/java/org/jskat/gui/javafx/main/JSkatMainWindowController.java
+++ b/jskat-javafx-gui/src/main/java/org/jskat/gui/javafx/main/JSkatMainWindowController.java
@@ -245,19 +245,19 @@ public class JSkatMainWindowController {
         final SwingNode swingNode = new SwingNode();
         final String tableName = event.tableName();
 
-        try {
-            SwingUtilities.invokeAndWait(() -> {
-                SkatTablePanel panel = null;
-                if (JSkatViewType.LOCAL_TABLE.equals(event.tableType())) {
-                    panel = new SkatTablePanel(tableName, JSkatViewImpl.actions);
-                } else if (JSkatViewType.ISS_TABLE.equals(event.tableType())) {
-                    panel = new ISSTablePanel(tableName, JSkatViewImpl.actions);
-                }
-                swingNode.setContent(panel);
-            });
-        } catch (InterruptedException | InvocationTargetException e) {
-            throw new RuntimeException(e);
-        }
+        SwingUtilities.invokeLater(() -> {
+            SkatTablePanel panel = null;
+            if (JSkatViewType.LOCAL_TABLE.equals(event.tableType())) {
+                panel = new SkatTablePanel(tableName, JSkatViewImpl.actions);
+            } else if (JSkatViewType.ISS_TABLE.equals(event.tableType())) {
+                panel = new ISSTablePanel(tableName, JSkatViewImpl.actions);
+            }
+
+            if (panel != null) {
+                final SkatTablePanel finalPanel = panel;
+                Platform.runLater(() -> swingNode.setContent(finalPanel));
+            }
+        });
 
         String tabTitle = null;
         String tabId = null;


### PR DESCRIPTION
In my environment (Mac OS amd64, openjdk@21) I was unable to create a local table. The program would hang after clicking "OK" in the table naming dialog box.

After digging, it looks like there was a deadlock between the AWT event thread and the JavaFX app thread. This change resolves that deadlock by creating the Swing components asynchrounously (`invokeLater` to create the table components and then `Platform.runLater` to set them up once created) so that the JavaFX thread remains unblocked.