### PR TITLE
Fix ouvert issues

### DIFF
--- a/jskat-base/src/main/java/org/jskat/data/GameContract.java
+++ b/jskat-base/src/main/java/org/jskat/data/GameContract.java
@@ -28,7 +28,7 @@ public record GameContract(
         Objects.requireNonNull(gameType);
         Objects.requireNonNull(ouvertCards);
 
-        if (ouvert && (ouvertCards.size() != 10)) {
+        if (ouvert && !ouvertCards.isEmpty() && (ouvertCards.size() != 10)) {
             throw new IllegalArgumentException("Validation failed: Wrong number of ouvert cards in ouvert game.");
         }
         if (!ouvert && !ouvertCards.isEmpty()) {

--- a/jskat-swing-gui/src/main/java/org/jskat/gui/swing/table/SkatTablePanel.java
+++ b/jskat-swing-gui/src/main/java/org/jskat/gui/swing/table/SkatTablePanel.java
@@ -471,6 +471,8 @@ public class SkatTablePanel extends AbstractTabPanel {
         }
 
         if (contract.ouvert()) {
+            getPlayerPanel(event.player).removeAllCards();
+            getPlayerPanel(event.player).addCards(contract.ouvertCards());
             getPlayerPanel(event.player).showCards();
         }
     }


### PR DESCRIPTION
- In local games, player panel cards need to be refreshed to show post-discard hand. Previously the initial hand was incorrectly being shown.
- For ISS games, post-game summaries may not include the ouvert cards. So amend the game summary with ouvert cards from the live gameplay data to ensure that game summary validation succeeds.