### PR TITLE
Fix ouvert issues

### DIFF
--- a/jskat-base/src/main/java/org/jskat/control/iss/IssController.java
+++ b/jskat-base/src/main/java/org/jskat/control/iss/IssController.java
@@ -490,6 +490,27 @@ public class IssController {
      * @param newGameData Game data
      */
     public void endGame(final String tableName, final SkatGameData newGameData) {
+        // If summary has ouvert but no cards, get them from live game data
+        final SkatGameData liveGame = gameData.get(tableName);
+        if (liveGame != null
+                && newGameData.getAnnouncement() != null
+                && newGameData.getAnnouncement().contract().ouvert()
+                && newGameData.getAnnouncement().contract().ouvertCards().isEmpty()
+                && liveGame.getAnnouncement() != null
+                && !liveGame.getAnnouncement().contract().ouvertCards().isEmpty()) {
+            final var liveContract = liveGame.getAnnouncement().contract();
+            final var newContract = newGameData.getAnnouncement().contract();
+            newGameData.setAnnouncement(new GameAnnouncement(
+                    new GameContract(
+                            newContract.gameType(),
+                            newContract.hand(),
+                            newContract.schneider(),
+                            newContract.schwarz(),
+                            newContract.ouvert(),
+                            liveContract.ouvertCards()),
+                    newGameData.getAnnouncement().discardedCards()));
+        }
+
         eventBus.post(new SkatGameStateChangedEvent(tableName, GameState.GAME_OVER));
         // FIXME: merge event and command
         eventBus.post(new TableGameMoveEvent(tableName, new GameFinishEvent(newGameData.getGameSummary())));

--- a/jskat-swing-gui/src/main/java/org/jskat/gui/swing/table/SkatTablePanel.java
+++ b/jskat-swing-gui/src/main/java/org/jskat/gui/swing/table/SkatTablePanel.java
@@ -471,6 +471,8 @@ public class SkatTablePanel extends AbstractTabPanel {
         }
 
         if (contract.ouvert()) {
+            getPlayerPanel(event.player).removeAllCards();
+            getPlayerPanel(event.player).addCards(contract.ouvertCards());
             getPlayerPanel(event.player).showCards();
         }
     }


### PR DESCRIPTION
- In local games, player panel cards need to be refreshed to show post-discard hand. Previously the initial hand was incorrectly being shown.
- For ISS games, post-game summaries may not include the ouvert cards. So amend the game summary with ouvert cards from the live gameplay data to ensure that game summary validation succeeds.